### PR TITLE
update policy version to v1 & change the default redisUrl

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: go-ratelimit
 description: A Ratelimit Service Helm chart for Kubernetes
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: 1.4.0
 dependencies:
 - name: "redis-sharded"

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "go-ratelimit.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -52,7 +52,7 @@ priorityClassName: ""
 
 podDisruptionBudget: {}
 
-redisUrl: "redis"
+redisUrl: "redish-backend"
 redisSocketType: "tcp"
 redisPort: 6379
 


### PR DESCRIPTION
1. fix warning:
> policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget

2. fix `ratelimit` can't connect to `redis` bug 

Signed-off-by: Gang Liu <gang.liu@daocloud.io>