### PR TITLE
fix: use config value in configmap

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -5,7 +5,4 @@ metadata:
   name: initconfigmap
 data:
   config-initconfigmap.yaml: |-
-    domain: initconfigmap
-    descriptors:
-      - key: generic_key
-        value: global
+{{ .Values.config | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -65,7 +65,10 @@ extraEnvs: []
 logLevel: debug
 
 config: |-
-  # Start with empty config
+  domain: initconfigmap
+  descriptors:
+    - key: generic_key
+      value: global
 
 
 redish:


### PR DESCRIPTION
Closes https://github.com/softonic/go-ratelimit-chart/issues/13.