### PR TITLE
Add value to declare additional containers

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             name: commonconfig-volume
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.containers }}
+        {{- toYaml .Values.containers | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -62,6 +62,8 @@ httpPort: 8080
 
 extraEnvs: []
 
+containers: []
+
 logLevel: debug
 
 config: |-


### PR DESCRIPTION
Adds a `containers` value to allow the specification of sidecars. Tested that the templating works both with and without overrides locally.